### PR TITLE
Version 2.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,11 @@ name: ci
 on: push
 jobs:
   test:
-    runs-on: macOS-10.14
+    runs-on: macOS-10.15
     steps:
       - uses: actions/checkout@v1
-      - name: Switch Xcode to 11.1
-        run: xcversion select 11.1
+      - name: Switch Xcode to 12.0
+        run: xcversion select 12.0
       - name: Build
         run: swift build -v
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,8 @@ jobs:
     runs-on: macOS-10.15
     steps:
       - uses: actions/checkout@v1
-      - name: Switch Xcode to 12.0
-        run: xcversion select 12.0
+      - name: Switch Xcode to 12.0.1
+        run: xcversion select 12.0.1
       - name: Build
         run: swift build -v
       - name: Test

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 
 import PackageDescription
 

--- a/README.md
+++ b/README.md
@@ -1,34 +1,25 @@
 # synchronized
 
-Synchronized is a simple (and simplified) re-implmentation of [Objective-C's @synchronized](http://www.opensource.apple.com/source/objc4/objc4-646/runtime/objc-sync.mm) for Swift.
+`Synchronized` provides a simple Swift-y implementation of a lock and a recursive lock. `Lock` wraps `os_unfair_lock`. `RecursiveLock` wraps `pthread_mutex_t`. `Synchronized`'s API is designed for convenience and simplicity. 
 
-Synchronized enables users to protect access to blocks of code by providing an object pointer as a parameter. The object pointer acts as a lock. Given the same object pointer, only one thread is permitted within a synchronized block at a time. For added convenience, classes are able to add conformance to the empty `Synchronized` protocol. Conforming to `Synchronized` grants the class access to the `sync` function, which uses `self` as the "lock" for blocks passed to it. 
+The two lock's APIs are identical and limited to two public methods: `func locked<T>(_ block: () throws -> T) rethrows -> T` and `func tryLocked(_ block: () throws -> Void) rethrows`. `locked()` blocks on contention and then executes the supplied closure, returning or throwing the closure's return value or thrown error. `tryLocked()` attemps to acquire the lock. If the lock can be acquired, the supplied closure is executed and `true` is returned. If the lock cannot be acquired, the closure is not executed and `false` is returned.
+
+## @synchonized replacement 
+
+_Synchronized started life as a simple (and simplified) re-implmentation of [Objective-C's @synchronized](http://www.opensource.apple.com/source/objc4/objc4-646/runtime/objc-sync.mm) for Swift. If you're interested in that version, you should look at [v1.2.1](https://github.com/shareup/synchronized/releases/tag/v1.2.1)._ 
 
 ## Usage
 
 ```swift
-final class Counter: Synchronized {
-  private var _value: Int = 0
+let lock = Lock()
+let lockInput: Int = 0
+let lockOutput = lock.locked { lockInput + 1 }
+XCTAssertEqual(1, lockOutput)
 
-  var currentValue: Int { return _value }
-
-  func increment() {
-    _value += 1
-  }
-
-  func synchronizedIncrement() {
-    self.sync { _value += 1 }
-  }
-}
-
-let counter = Counter()
-
-DispatchQueue.global().async {
-  synchronized(counter) { counter.increment() }
-}
-DispatchQueue.global().async {
-  counter.synchronizedIncrement()
-}
+let recursiveLock = RecursiveLock()
+let recursiveLockInput: Int = 0
+let recursiveLockOutput = recursiveLock.locked { recursiveLockInput + 1 }
+XCTAssertEqual(1, recursiveLockOutput)
 ```
 
 ## Installation
@@ -40,7 +31,7 @@ To use Synchronized with the Swift Package Manager, add a dependency to your Pac
 ```swift
 let package = Package(
   dependencies: [
-    .package(url: "https://github.com/shareup/synchronized.git", .upToNextMajor(from: "2.0.0"))
+    .package(url: "https://github.com/shareup/synchronized.git", .upToNextMajor(from: "2.1.0"))
   ]
 )
 ```

--- a/Sources/Synchronized/Lock.swift
+++ b/Sources/Synchronized/Lock.swift
@@ -13,15 +13,20 @@ public final class Lock {
     }
 
     public func locked<T>(_ block: () throws -> T) rethrows -> T {
+        // https://developer.apple.com/documentation/os/1646466-os_unfair_lock_lock
         os_unfair_lock_lock(_backing)
         defer { os_unfair_lock_unlock(_backing) }
         return try block()
     }
 
-    public func tryLocked(_ block: () throws -> Void) rethrows {
+    public func tryLocked(_ block: () throws -> Void) rethrows -> Bool {
+        // https://developer.apple.com/documentation/os/1646469-os_unfair_lock_trylock
         if os_unfair_lock_trylock(_backing) {
             defer { os_unfair_lock_unlock(_backing) }
             try block()
+            return true
+        } else {
+            return false
         }
     }
 }

--- a/Sources/Synchronized/RecursiveLock.swift
+++ b/Sources/Synchronized/RecursiveLock.swift
@@ -16,15 +16,21 @@ final public class RecursiveLock {
     }
 
     public func locked<T>(_ block: () throws -> T) rethrows -> T {
-        pthread_mutex_lock(&_backing)
+        let ret = pthread_mutex_lock(&_backing)
+        // https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/pthread_mutex_lock.3.html
+        precondition(ret == 0, "Could not acquire lock: '\(ret)'")
         defer { pthread_mutex_unlock(&_backing) }
         return try block()
     }
 
-    public func tryLocked(_ block: () throws -> Void) rethrows {
+    public func tryLocked(_ block: () throws -> Void) rethrows -> Bool {
+        // https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/pthread_mutex_trylock.3.html#//apple_ref/doc/man/3/pthread_mutex_trylock
         if pthread_mutex_trylock(&_backing) == 0 {
             defer { pthread_mutex_unlock(&_backing) }
             try block()
+            return true
+        } else {
+            return false
         }
     }
 }

--- a/Tests/SynchronizedTests/SynchronizedTests.swift
+++ b/Tests/SynchronizedTests/SynchronizedTests.swift
@@ -113,14 +113,14 @@ final class SynchronizedTests: XCTestCase {
     func testSuccessfulTryLockedWithLock() {
         let counter = Counter()
         let lock = Lock()
-        lock.tryLocked { counter.increment() }
+        XCTAssertTrue(lock.tryLocked { counter.increment() })
         XCTAssertEqual(1, counter.currentValue)
     }
 
     func testSuccessfulTryLockedWithRecursiveLock() {
         let counter = Counter()
         let lock = RecursiveLock()
-        lock.tryLocked { counter.increment() }
+        XCTAssertTrue(lock.tryLocked { counter.increment() })
         XCTAssertEqual(1, counter.currentValue)
     }
 
@@ -133,9 +133,7 @@ final class SynchronizedTests: XCTestCase {
         group.enter()
         lock.locked {
             count += 1
-            lock.tryLocked {
-                count += 1
-            }
+            XCTAssertFalse(lock.tryLocked { count += 1 })
             group.leave()
         }
         group.wait()
@@ -152,7 +150,7 @@ final class SynchronizedTests: XCTestCase {
         (0..<iterations).forEach { _ in
             group.enter()
             DispatchQueue.global().async {
-                lock.tryLocked { counter.increment() }
+                _ = lock.tryLocked { counter.increment() }
                 group.leave()
             }
         }
@@ -171,7 +169,7 @@ final class SynchronizedTests: XCTestCase {
         (0..<iterations).forEach { _ in
             group.enter()
             DispatchQueue.global().async {
-                lock.tryLocked { counter.increment() }
+                _ = lock.tryLocked { counter.increment() }
                 group.leave()
             }
         }


### PR DESCRIPTION
- [x] Return `Bool` from `tryLocked()` indicating success or failure
- [x] Update README.md