### PR TITLE
Improve deinit

### DIFF
--- a/Sources/Synchronized/Lock.swift
+++ b/Sources/Synchronized/Lock.swift
@@ -1,28 +1,29 @@
 import Foundation
 
 public final class Lock {
-    private var _backing: UnsafeMutablePointer<os_unfair_lock>
+    private var backing: UnsafeMutablePointer<os_unfair_lock>
 
     public init() {
-        _backing = UnsafeMutablePointer<os_unfair_lock>.allocate(capacity: 1)
-        _backing.initialize(to: os_unfair_lock())
+        backing = UnsafeMutablePointer<os_unfair_lock>.allocate(capacity: 1)
+        backing.initialize(to: os_unfair_lock())
     }
 
     deinit {
-        _backing.deallocate()
+        backing.deinitialize(count: 1)
+        backing.deallocate()
     }
 
     public func locked<T>(_ block: () throws -> T) rethrows -> T {
         // https://developer.apple.com/documentation/os/1646466-os_unfair_lock_lock
-        os_unfair_lock_lock(_backing)
-        defer { os_unfair_lock_unlock(_backing) }
+        os_unfair_lock_lock(backing)
+        defer { os_unfair_lock_unlock(backing) }
         return try block()
     }
 
     public func tryLocked(_ block: () throws -> Void) rethrows -> Bool {
         // https://developer.apple.com/documentation/os/1646469-os_unfair_lock_trylock
-        if os_unfair_lock_trylock(_backing) {
-            defer { os_unfair_lock_unlock(_backing) }
+        if os_unfair_lock_trylock(backing) {
+            defer { os_unfair_lock_unlock(backing) }
             try block()
             return true
         } else {

--- a/Sources/Synchronized/RecursiveLock.swift
+++ b/Sources/Synchronized/RecursiveLock.swift
@@ -1,32 +1,43 @@
 import Foundation
 
-final public class RecursiveLock {
-    private var _backing = pthread_mutex_t()
+public final class RecursiveLock {
+    private var backing: UnsafeMutablePointer<pthread_mutex_t>
 
     public init() {
+        backing = UnsafeMutablePointer<pthread_mutex_t>.allocate(capacity: 1)
+        backing.initialize(to: pthread_mutex_t())
+
         var attributes = pthread_mutexattr_t()
-        guard pthread_mutexattr_init(&attributes) == 0 else { preconditionFailure() }
-        pthread_mutexattr_settype(&attributes, PTHREAD_MUTEX_RECURSIVE)
-        guard pthread_mutex_init(&_backing, &attributes) == 0 else { preconditionFailure() }
+        guard pthread_mutexattr_init(&attributes) == 0
+        else { preconditionFailure() }
+
+        guard pthread_mutexattr_settype(&attributes, PTHREAD_MUTEX_RECURSIVE) == 0
+        else { preconditionFailure() }
+
+        guard pthread_mutex_init(backing, &attributes) == 0
+        else { preconditionFailure() }
+
         pthread_mutexattr_destroy(&attributes)
     }
 
     deinit {
-        pthread_mutex_destroy(&_backing)
+        pthread_mutex_destroy(backing)
+        backing.deinitialize(count: 1)
+        backing.deallocate()
     }
 
     public func locked<T>(_ block: () throws -> T) rethrows -> T {
-        let ret = pthread_mutex_lock(&_backing)
+        let ret = pthread_mutex_lock(backing)
         // https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/pthread_mutex_lock.3.html
         precondition(ret == 0, "Could not acquire lock: '\(ret)'")
-        defer { pthread_mutex_unlock(&_backing) }
+        defer { pthread_mutex_unlock(backing) }
         return try block()
     }
 
     public func tryLocked(_ block: () throws -> Void) rethrows -> Bool {
         // https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/pthread_mutex_trylock.3.html#//apple_ref/doc/man/3/pthread_mutex_trylock
-        if pthread_mutex_trylock(&_backing) == 0 {
-            defer { pthread_mutex_unlock(&_backing) }
+        if pthread_mutex_trylock(backing) == 0 {
+            defer { pthread_mutex_unlock(backing) }
             try block()
             return true
         } else {


### PR DESCRIPTION
- [x] Call `UnsafeMutablePointer.deinitialize()` inside of `deinit`
- [x] Store `pthread_mutex_t` inside of an `UnsafeMutablePointer` to potentially avoid [problems with Swift's `&` operator](https://developer.apple.com/forums/thread/674633)